### PR TITLE
Revert "Migrate example buildSrc off Project.exec for Gradle 9"

### DIFF
--- a/examples/biometry-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/BuildTask.kt
+++ b/examples/biometry-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/BuildTask.kt
@@ -5,17 +5,10 @@ import org.gradle.api.GradleException
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
-import org.gradle.process.ExecOperations
 
-abstract class BuildTask : DefaultTask() {
-    @get:Inject
-    abstract val execOperations: ExecOperations
-
+open class BuildTask : DefaultTask() {
     @Input
     var rootDirRel: String? = null
-    @Input
-    var projectDir: String? = null
     @Input
     var target: String? = null
     @Input
@@ -34,7 +27,7 @@ abstract class BuildTask : DefaultTask() {
                     "$executable.cmd",
                     "$executable.bat",
                 )
-
+                
                 var lastException: Exception = e
                 for (fallback in fallbacks) {
                     try {
@@ -57,13 +50,13 @@ abstract class BuildTask : DefaultTask() {
         val release = release ?: throw GradleException("release cannot be null")
         val args = listOf("tauri", "android", "android-studio-script");
 
-        execOperations.exec {
-            workingDir(File(projectDir, rootDirRel))
+        project.exec {
+            workingDir(File(project.projectDir, rootDirRel))
             executable(executable)
             args(args)
-            if (logger.isEnabled(LogLevel.DEBUG)) {
+            if (project.logger.isEnabled(LogLevel.DEBUG)) {
                 args("-vv")
-            } else if (logger.isEnabled(LogLevel.INFO)) {
+            } else if (project.logger.isEnabled(LogLevel.INFO)) {
                 args("-v")
             }
             if (release) {

--- a/examples/biometry-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/RustPlugin.kt
+++ b/examples/biometry-demo/src-tauri/gen/android/buildSrc/src/main/java/com/test/app/kotlin/RustPlugin.kt
@@ -63,14 +63,13 @@ open class RustPlugin : Plugin<Project> {
                     val targetName = targetPair.value
                     val targetArch = archList[targetPair.index]
                     val targetArchCapitalized = targetArch.replaceFirstChar { it.uppercase() }
-                    val targetBuildTask = project.tasks.register(
+                    val targetBuildTask = project.tasks.maybeCreate(
                         "rustBuild$targetArchCapitalized$profileCapitalized",
                         BuildTask::class.java
-                    ) {
+                    ).apply {
                         group = TASK_GROUP
                         description = "Build dynamic library in $profile mode for $targetArch"
                         rootDirRel = config.rootDirRel
-                        projectDir = project.projectDir.path
                         target = targetName
                         release = profile == "release"
                     }


### PR DESCRIPTION
Reverts #138.

The `buildSrc` migration only mattered as a step towards Gradle 9 in the example app, and that path is blocked further down: AGP 9 needs the tauri android library's own build script rewritten for built-in Kotlin, which the current tauri release does not have. Until tauri moves, the example stays on the generated `buildSrc` as-is.